### PR TITLE
[YW-152] Email case sensitivity issue in DTOs

### DIFF
--- a/src/main/java/com/yushan/backend/dto/EmailVerificationRequestDTO.java
+++ b/src/main/java/com/yushan/backend/dto/EmailVerificationRequestDTO.java
@@ -1,14 +1,21 @@
 package com.yushan.backend.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Data;
 
-@Data
 public class EmailVerificationRequestDTO {
 
     @Schema(description = "New email to verify before changing",
             example = "newuser@example.com")
     private String email;
+
+    // Getters and Setters
+    public String getEmail() {
+        return email != null ? email.trim().toLowerCase(java.util.Locale.ROOT) : null;
+    }
+
+    public void setEmail(String email) {
+        this.email = email != null ? email.trim().toLowerCase(java.util.Locale.ROOT) : null;
+    }
 }
 
 

--- a/src/main/java/com/yushan/backend/dto/UserLoginRequestDTO.java
+++ b/src/main/java/com/yushan/backend/dto/UserLoginRequestDTO.java
@@ -9,4 +9,12 @@ public class UserLoginRequestDTO {
     private String email;
     @NotBlank(message = "password cannot be empty")
     private String password;
+
+    public String getEmail() {
+        return email != null ? email.trim().toLowerCase(java.util.Locale.ROOT) : null;
+    }
+
+    public void setEmail(String email) {
+        this.email = email != null ? email.trim().toLowerCase(java.util.Locale.ROOT) : null;
+    }
 }


### PR DESCRIPTION
Previously, for Email DTOs, the system did not correctly handle email normalization (trimming + lowercasing). As a result, when users entered their email in uppercase, the BE returned an incorrect error message:
> "Invalid verification code or code expired."
The issue has now been fixed by explicitly handling trimming and lowercasing in the DTO logic.

Steps to Reproduce (Before Fix):
1. Go to Register/Login page.
2. Enter an email in uppercase (e.g., TESTUSER@EXAMPLE.COM).
3. Request and receive verification code.
4. Enter the correct verification code.
5. Submit.
6. Error "Invalid verification code or code expired" was shown.

**Actual Result (Before Fix):**
User enters uppercase email (e.g., USER@GMAIL.COM).
Even with the correct verification code, BE responded with "Invalid verification code or code expired."

**Expected Result (After Fix):**
Email normalization (trim + lowercase) happens consistently in BE.
Verification succeeds if code is correct, regardless of case.

Fix Implemented:
- Removed Lombok.
- Added explicit normalization (trim + lowercase) in Email DTOs.
- Issue no longer reproducible.