### PR TITLE
[YW-97]Design and implement leaderboard APIs (Novels, Users, Authors).

### DIFF
--- a/src/main/java/com/yushan/backend/config/SecurityConfig.java
+++ b/src/main/java/com/yushan/backend/config/SecurityConfig.java
@@ -126,6 +126,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/history/**").authenticated()
                 .requestMatchers("/api/comments/**").authenticated()
                 .requestMatchers("/api/reviews/**").authenticated()
+                .requestMatchers("/api/ranking/**").authenticated()
 
                 // Admin endpoints - require admin role
                 .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/yushan/backend/controller/RankingController.java
+++ b/src/main/java/com/yushan/backend/controller/RankingController.java
@@ -1,0 +1,69 @@
+package com.yushan.backend.controller;
+
+import com.yushan.backend.dto.*;
+import com.yushan.backend.service.RankingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ranking")
+@CrossOrigin(origins = "*")
+public class RankingController {
+
+    @Autowired
+    private RankingService rankingService;
+
+    /**
+     *
+     * @param page
+     * @param size
+     * @param sortType: view/vote
+     * @param categoryId: can be null
+     * @param timeRange: weekly, monthly, overall
+     * @return
+     */
+    @GetMapping("/novel")
+    public ApiResponse<PageResponseDTO<NovelDetailResponseDTO>> getNovelRanking (
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "50") Integer size,
+            @RequestParam(value = "sortType", defaultValue = "view") String sortType,
+            @RequestParam(value = "category", required = false) Integer categoryId,
+            @RequestParam(value = "timeRange", defaultValue = "overall") String timeRange) {
+        PageResponseDTO<NovelDetailResponseDTO> response = rankingService.rankNovel(page, size, sortType, categoryId, timeRange);
+        return ApiResponse.success("Novels retrieved successfully", response);
+    }
+
+    /**
+     *
+     * @param page
+     * @param size
+     * @param timeRange
+     * @return
+     */
+    @GetMapping("/user")
+    public ApiResponse<PageResponseDTO<UserProfileResponseDTO>> getUserRanking (
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "50") Integer size,
+            @RequestParam(value = "timeRange", defaultValue = "overall") String timeRange) {
+        PageResponseDTO<UserProfileResponseDTO> response = rankingService.rankUser(page,size, timeRange);
+        return ApiResponse.success("Novels retrieved successfully", response);
+    }
+
+    /**
+     *
+     * @param page
+     * @param size
+     * @param sortType: novelNum/view/vote
+     * @param timeRange
+     * @return
+     */
+    @GetMapping("/author")
+    public ApiResponse<PageResponseDTO<AuthorResponseDTO>> getAuthorRanking (
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "50") Integer size,
+            @RequestParam(value = "sortType", defaultValue = "vote") String sortType,
+            @RequestParam(value = "timeRange", defaultValue = "overall") String timeRange) {
+        PageResponseDTO<AuthorResponseDTO> response = rankingService.rankAuthor(page,size, sortType, timeRange);
+        return ApiResponse.success("Novels retrieved successfully", response);
+    }
+}

--- a/src/main/java/com/yushan/backend/dao/NovelMapper.java
+++ b/src/main/java/com/yushan/backend/dao/NovelMapper.java
@@ -1,5 +1,6 @@
 package com.yushan.backend.dao;
 
+import com.yushan.backend.dto.AuthorResponseDTO;
 import com.yushan.backend.dto.NovelSearchRequestDTO;
 import com.yushan.backend.entity.Novel;
 import org.apache.ibatis.annotations.Mapper;
@@ -25,4 +26,16 @@ public interface NovelMapper {
     List<Novel> selectNovelsWithPagination(@Param("req") NovelSearchRequestDTO req);
     
     long countNovels(@Param("req") NovelSearchRequestDTO req);
+
+    // Ranking methods
+    List<Novel> selectNovelsByRanking(@Param("categoryId") Integer categoryId,
+                                      @Param("sortType") String sortType,
+                                      @Param("offset") int offset,
+                                      @Param("limit") int limit);
+
+    long countNovelsByRanking(@Param("categoryId") Integer categoryId);
+
+    List<AuthorResponseDTO> selectAuthorsByRanking(@Param("sortType") String sortType,
+                                                   @Param("offset") int offset,
+                                                   @Param("limit") int limit);
 }

--- a/src/main/java/com/yushan/backend/dao/UserMapper.java
+++ b/src/main/java/com/yushan/backend/dao/UserMapper.java
@@ -2,6 +2,9 @@ package com.yushan.backend.dao;
 
 import com.yushan.backend.entity.User;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 import java.util.UUID;
 
@@ -16,6 +19,13 @@ public interface UserMapper {
     User selectByPrimaryKey(UUID uuid);
 
     User selectByEmail(String email);
+
+    List<User> selectUsersByRanking(@Param("offset") int offset,
+                                    @Param("limit") int limit);
+
+    long countAllUsers();
+
+    long countAllAuthors();
 
     int updateByPrimaryKeySelective(User record);
 

--- a/src/main/java/com/yushan/backend/dto/AuthorResponseDTO.java
+++ b/src/main/java/com/yushan/backend/dto/AuthorResponseDTO.java
@@ -1,0 +1,13 @@
+package com.yushan.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class AuthorResponseDTO {
+    private String uuid;
+    private String username;
+    private String avatarUrl;
+    private Integer novelNum;
+    private long totalVoteCnt;
+    private Long totalViewCnt;
+}

--- a/src/main/java/com/yushan/backend/service/RankingService.java
+++ b/src/main/java/com/yushan/backend/service/RankingService.java
@@ -23,7 +23,7 @@ public class RankingService {
     @Autowired
     private UserMapper userMapper;
 
-    private final int MAX_TOTAL_RECORDS = 100;
+    private static final int MAX_TOTAL_RECORDS = 100;
 
     /**
      * @param page

--- a/src/main/java/com/yushan/backend/service/RankingService.java
+++ b/src/main/java/com/yushan/backend/service/RankingService.java
@@ -1,0 +1,142 @@
+package com.yushan.backend.service;
+
+import com.yushan.backend.dto.AuthorResponseDTO;
+import com.yushan.backend.dto.NovelDetailResponseDTO;
+import com.yushan.backend.dto.PageResponseDTO;
+import com.yushan.backend.dto.UserProfileResponseDTO;
+import com.yushan.backend.entity.Novel;
+import com.yushan.backend.dao.NovelMapper;
+import com.yushan.backend.dao.UserMapper;
+import com.yushan.backend.entity.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class RankingService {
+
+    @Autowired
+    private NovelMapper novelMapper;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    private final int MAX_TOTAL_RECORDS = 100;
+
+    /**
+     * @param page
+     * @param size
+     * @param sortType
+     * @param categoryId
+     * @param timeRange
+     * @return
+     */
+    public PageResponseDTO<NovelDetailResponseDTO> rankNovel(
+            Integer page,
+            Integer size,
+            String sortType,
+            Integer categoryId,
+            String timeRange) {
+
+        int offset = page * size;
+
+        if (offset >= MAX_TOTAL_RECORDS) {
+            return PageResponseDTO.of(List.of(), 0L, page, size);
+        }
+
+        int adjustedSize = Math.min(size, MAX_TOTAL_RECORDS - offset);
+
+        List<Novel> novels = novelMapper.selectNovelsByRanking(categoryId, sortType, offset, adjustedSize);
+
+        long total = Math.min(novelMapper.countNovelsByRanking(categoryId), MAX_TOTAL_RECORDS);
+
+        List<NovelDetailResponseDTO> novelDTOs = novels.stream()
+                .map(this::convertToNovelDetailResponseDTO)
+                .collect(Collectors.toList());
+
+        return PageResponseDTO.of(novelDTOs, total, page, size);
+    }
+
+    /**
+     * rank user by exp
+     * @param page
+     * @param size
+     * @param timeRange
+     * @return
+     */
+    public PageResponseDTO<UserProfileResponseDTO> rankUser(
+            Integer page,
+            Integer size,
+            String timeRange) {
+
+        int offset = page * size;
+
+        if (offset >= MAX_TOTAL_RECORDS) {
+            return PageResponseDTO.of(List.of(), 0L, page, size);
+        }
+
+        int adjustedSize = Math.min(size, MAX_TOTAL_RECORDS - offset);
+
+        List<User> users = userMapper.selectUsersByRanking(offset, adjustedSize);
+
+        long total = Math.min(userMapper.countAllUsers(), MAX_TOTAL_RECORDS);
+
+        List<UserProfileResponseDTO> userDTOs = users.stream()
+                .map(this::convertToUserProfileResponseDTO)
+                .collect(Collectors.toList());
+
+        return PageResponseDTO.of(userDTOs, total, page, size);
+    }
+
+    /**
+     *
+     * @param page
+     * @param size
+     * @param sortType
+     * @param timeRange
+     * @return
+     */
+    public PageResponseDTO<AuthorResponseDTO> rankAuthor(
+            Integer page,
+            Integer size,
+            String sortType,
+            String timeRange) {
+
+        int offset = page * size;
+
+        if (offset >= MAX_TOTAL_RECORDS) {
+            return PageResponseDTO.of(List.of(), 0L, page, size);
+        }
+
+        int adjustedSize = Math.min(size, MAX_TOTAL_RECORDS - offset);
+
+        List<AuthorResponseDTO> authors = novelMapper.selectAuthorsByRanking(sortType, offset, adjustedSize);
+
+        long total = Math.min(userMapper.countAllAuthors(), MAX_TOTAL_RECORDS);
+
+        return PageResponseDTO.of(authors, total, page, size);
+    }
+
+    private UserProfileResponseDTO convertToUserProfileResponseDTO(User user) {
+        UserProfileResponseDTO dto = new UserProfileResponseDTO();
+        dto.setUuid(user.getUuid().toString());
+        dto.setUsername(user.getUsername());
+        dto.setExp(user.getExp());
+        dto.setLevel(user.getLevel());
+        dto.setAvatarUrl(user.getAvatarUrl());
+        return dto;
+    }
+
+    private NovelDetailResponseDTO convertToNovelDetailResponseDTO(Novel novel) {
+        NovelDetailResponseDTO dto = new NovelDetailResponseDTO();
+        dto.setId(novel.getId());
+        dto.setTitle(novel.getTitle());
+        dto.setViewCnt(novel.getViewCnt());
+        dto.setVoteCnt(novel.getVoteCnt());
+        dto.setCoverImgUrl(novel.getCoverImgUrl());
+        dto.setCategoryId(novel.getCategoryId());
+        return dto;
+    }
+}

--- a/src/main/resources/application-integration-test.properties
+++ b/src/main/resources/application-integration-test.properties
@@ -27,6 +27,13 @@ spring.testcontainers.enabled=true
 # - spring.data.redis.host (Redis container)
 # - spring.data.redis.port (Redis container)
 
+# Flyway Configuration for Integration Tests
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.baseline-on-migrate=true
+spring.flyway.validate-on-migrate=true
+spring.flyway.clean-disabled=true
+
 # JPA/Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect

--- a/src/main/resources/application-integration-test.properties
+++ b/src/main/resources/application-integration-test.properties
@@ -28,7 +28,7 @@ spring.testcontainers.enabled=true
 # - spring.data.redis.port (Redis container)
 
 # JPA/Hibernate Configuration
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 

--- a/src/main/resources/application-integration-test.properties
+++ b/src/main/resources/application-integration-test.properties
@@ -27,15 +27,8 @@ spring.testcontainers.enabled=true
 # - spring.data.redis.host (Redis container)
 # - spring.data.redis.port (Redis container)
 
-# Flyway Configuration for Integration Tests
-spring.flyway.enabled=true
-spring.flyway.locations=classpath:db/migration
-spring.flyway.baseline-on-migrate=true
-spring.flyway.validate-on-migrate=true
-spring.flyway.clean-disabled=true
-
 # JPA/Hibernate Configuration
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
     restart:
       enabled: false
   flyway:
-    enabled: ${FLYWAY_ENABLED:true}
+    enabled: true
     locations: classpath:db/migration
     baseline-on-migrate: true
     validate-on-migrate: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
     restart:
       enabled: false
   flyway:
-    enabled: true
+    enabled: false
     locations: classpath:db/migration
     baseline-on-migrate: true
     validate-on-migrate: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
     restart:
       enabled: false
   flyway:
-    enabled: ${FLYWAY_ENABLED:false}
+    enabled: ${FLYWAY_ENABLED:true}
     locations: classpath:db/migration
     baseline-on-migrate: true
     validate-on-migrate: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
     restart:
       enabled: false
   flyway:
-    enabled: false
+    enabled: ${FLYWAY_ENABLED:true}
     locations: classpath:db/migration
     baseline-on-migrate: true
     validate-on-migrate: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,7 +47,7 @@ spring:
     restart:
       enabled: false
   flyway:
-    enabled: ${FLYWAY_ENABLED:true}
+    enabled: ${FLYWAY_ENABLED:false}
     locations: classpath:db/migration
     baseline-on-migrate: true
     validate-on-migrate: true

--- a/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -1,7 +1,7 @@
 -- Initial database schema for Yushan Backend
 -- This migration creates all the basic tables
 
-CREATE TABLE users if not exists(
+CREATE TABLE IF NOT EXISTS users(
     uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     email VARCHAR(255) NOT NULL UNIQUE,
     username VARCHAR(100) NOT NULL,
@@ -15,18 +15,18 @@ CREATE TABLE users if not exists(
     is_author BOOLEAN NOT NULL DEFAULT FALSE,
     is_admin BOOLEAN NOT NULL DEFAULT FALSE,
     level INTEGER NOT NULL DEFAULT 1,
-    exp DOUBLE NOT NULL PRECISION DEFAULT 0.0,
-    yuan DOUBLE NOT NULL PRECISION DEFAULT 0.0,
-    read_time DOUBLE NOT NULL PRECISION DEFAULT 0.0,
+    exp DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    yuan DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    read_time DOUBLE PRECISION NOT NULL DEFAULT 0.0,
     read_book_num INTEGER NOT NULL DEFAULT 0,
     create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    last_login TIMESTAMP NOT NULL,
-    last_active TIMESTAMP NOT NULL
+    last_login TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_active TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Category table (required by novel.category_id FK)
-CREATE TABLE category if not exists (
+CREATE TABLE IF NOT EXISTS category (
     id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
@@ -37,7 +37,7 @@ CREATE TABLE category if not exists (
 );
 
 -- Novel table
-CREATE TABLE novel if not exists(
+CREATE TABLE IF NOT EXISTS novel(
     id SERIAL PRIMARY KEY,
     uuid UUID NOT NULL DEFAULT gen_random_uuid(),
     title VARCHAR(255) NOT NULL,
@@ -63,7 +63,7 @@ CREATE TABLE novel if not exists(
     CONSTRAINT fk_novel_category FOREIGN KEY (category_id) REFERENCES category(id)
 );
 
-CREATE TABLE library if not exists(
+CREATE TABLE IF NOT EXISTS library(
     id SERIAL PRIMARY KEY,
     uuid UUID NOT NULL,
     user_id UUID NOT NULL,
@@ -71,7 +71,7 @@ CREATE TABLE library if not exists(
     update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE novel_library if not exists (
+CREATE TABLE IF NOT EXISTS novel_library (
    id SERIAL PRIMARY KEY,
    library_id INTEGER NOT NULL,
    novel_id INTEGER NOT NULL,

--- a/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -1,32 +1,32 @@
 -- Initial database schema for Yushan Backend
 -- This migration creates all the basic tables
 
-CREATE TABLE users (
+CREATE TABLE users if not exists(
     uuid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     email VARCHAR(255) NOT NULL UNIQUE,
     username VARCHAR(100) NOT NULL,
     hash_password VARCHAR(255) NOT NULL,
-    email_verified BOOLEAN DEFAULT FALSE,
-    avatar_url VARCHAR(500),
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    avatar_url VARCHAR(500) NOT NULL,
     profile_detail TEXT,
     birthday DATE,
-    gender INTEGER,
-    status INTEGER DEFAULT 1,
-    is_author BOOLEAN DEFAULT FALSE,
-    is_admin BOOLEAN DEFAULT FALSE,
-    level INTEGER DEFAULT 1,
-    exp DOUBLE PRECISION DEFAULT 0.0,
-    yuan DOUBLE PRECISION DEFAULT 0.0,
-    read_time DOUBLE PRECISION DEFAULT 0.0,
-    read_book_num INTEGER DEFAULT 0,
-    create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    last_login TIMESTAMP,
-    last_active TIMESTAMP
+    gender INTEGER NOT NULL,
+    status INTEGER NOT NULL DEFAULT 1,
+    is_author BOOLEAN NOT NULL DEFAULT FALSE,
+    is_admin BOOLEAN NOT NULL DEFAULT FALSE,
+    level INTEGER NOT NULL DEFAULT 1,
+    exp DOUBLE NOT NULL PRECISION DEFAULT 0.0,
+    yuan DOUBLE NOT NULL PRECISION DEFAULT 0.0,
+    read_time DOUBLE NOT NULL PRECISION DEFAULT 0.0,
+    read_book_num INTEGER NOT NULL DEFAULT 0,
+    create_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_login TIMESTAMP NOT NULL,
+    last_active TIMESTAMP NOT NULL
 );
 
 -- Category table (required by novel.category_id FK)
-CREATE TABLE category (
+CREATE TABLE category if not exists (
     id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
@@ -37,7 +37,7 @@ CREATE TABLE category (
 );
 
 -- Novel table
-CREATE TABLE novel (
+CREATE TABLE novel if not exists(
     id SERIAL PRIMARY KEY,
     uuid UUID NOT NULL DEFAULT gen_random_uuid(),
     title VARCHAR(255) NOT NULL,
@@ -63,7 +63,7 @@ CREATE TABLE novel (
     CONSTRAINT fk_novel_category FOREIGN KEY (category_id) REFERENCES category(id)
 );
 
-CREATE TABLE library (
+CREATE TABLE library if not exists(
     id SERIAL PRIMARY KEY,
     uuid UUID NOT NULL,
     user_id UUID NOT NULL,
@@ -71,7 +71,7 @@ CREATE TABLE library (
     update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE novel_library (
+CREATE TABLE novel_library if not exists (
    id SERIAL PRIMARY KEY,
    library_id INTEGER NOT NULL,
    novel_id INTEGER NOT NULL,

--- a/src/main/resources/db/migration/V3__Seed_data.sql
+++ b/src/main/resources/db/migration/V3__Seed_data.sql
@@ -10,6 +10,8 @@ INSERT INTO users (
     username,
     hash_password,
     email_verified,
+    avatar_url,
+    gender,
     is_admin,
     is_author,
     status,
@@ -19,13 +21,17 @@ INSERT INTO users (
     read_time,
     read_book_num,
     create_time,
-    update_time
+    update_time,
+    last_login,
+    last_active
 ) VALUES (
     gen_random_uuid(),
     'admin@yushan.com',
     'admin',
     '$2a$10$VXLDKUp3hDHJn9a17ZNsI.ZJZi.bWjwqLrkjEIug4pHGt1OsUGR5G',
     true,
+    'user.png',
+    0,
     true,
     true,
     1,
@@ -35,6 +41,8 @@ INSERT INTO users (
     0.0,
     0,
     CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP,
     CURRENT_TIMESTAMP
 );
 
@@ -42,22 +50,21 @@ INSERT INTO users (
 -- This runs after schema (010) and indexes (020)
 
 -- Insert all categories in one statement
-INSERT INTO category (name, description, slug, is_active) VALUES
-('Action', 'Action-packed novels with thrilling sequences', 'action', true),
-('Adventure', 'Epic journeys and exciting expeditions', 'adventure', true),
-('Martial Arts', 'Cultivation and martial arts stories', 'martial-arts', true),
-('Fantasy', 'Magical worlds and supernatural elements', 'fantasy', true),
-('Sci-Fi', 'Science fiction and futuristic stories', 'sci-fi', true),
-('Urban', 'Contemporary city life and modern settings', 'urban', true),
-('Historical', 'Stories set in historical periods', 'historical', true),
-('Eastern Fantasy', 'Chinese fantasy and mythology', 'eastern-fantasy', true),
-('Wuxia', 'Traditional Chinese martial arts fiction', 'wuxia', true),
-('Xianxia', 'Immortal heroes and cultivation', 'xianxia', true),
-('Military', 'Military strategy and warfare', 'military', true),
-('Sports', 'Competitive sports and athletics', 'sports', true),
-('Romance', 'Love stories and relationships', 'romance', true),
-('Drama', 'Dramatic and emotional narratives', 'drama', true),
-('Slice of Life', 'Everyday life and realistic situations', 'slice-of-life', true),
-('School Life', 'School and campus stories', 'school-life', true),
-('Comedy', 'Humorous and lighthearted tales', 'comedy', true)
-ON CONFLICT (slug) DO NOTHING;
+INSERT INTO category (name, description, slug, is_active, create_time, update_time) VALUES
+('Action', 'Action-packed novels with thrilling sequences', 'action', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Adventure', 'Epic journeys and exciting expeditions', 'adventure', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Martial Arts', 'Cultivation and martial arts stories', 'martial-arts', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Fantasy', 'Magical worlds and supernatural elements', 'fantasy', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Sci-Fi', 'Science fiction and futuristic stories', 'sci-fi', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Urban', 'Contemporary city life and modern settings', 'urban', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Historical', 'Stories set in historical periods', 'historical', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Eastern Fantasy', 'Chinese fantasy and mythology', 'eastern-fantasy', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Wuxia', 'Traditional Chinese martial arts fiction', 'wuxia', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Xianxia', 'Immortal heroes and cultivation', 'xianxia', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Military', 'Military strategy and warfare', 'military', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Sports', 'Competitive sports and athletics', 'sports', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Romance', 'Love stories and relationships', 'romance', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Drama', 'Dramatic and emotional narratives', 'drama', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Slice of Life', 'Everyday life and realistic situations', 'slice-of-life', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('School Life', 'School and campus stories', 'school-life', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+('Comedy', 'Humorous and lighthearted tales', 'comedy', true, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/main/resources/mapper/NovelMapper.xml
+++ b/src/main/resources/mapper/NovelMapper.xml
@@ -382,4 +382,68 @@
     from novel
     <include refid="Novel_Where" />
   </select>
+
+    <select id="selectNovelsByRanking" resultMap="BaseResultMap">
+        SELECT
+        <include refid="Base_Column_List" />
+        FROM novel
+        <where>
+            is_valid = true
+            <if test="categoryId != null and categoryId > 0">
+                AND category_id = #{categoryId,jdbcType=INTEGER}
+            </if>
+        </where>
+        <choose>
+            <when test="sortType == 'view'">
+                ORDER BY view_cnt DESC
+            </when>
+            <when test="sortType == 'vote'">
+                ORDER BY vote_cnt DESC
+            </when>
+            <otherwise>
+                ORDER BY view_cnt DESC
+            </otherwise>
+        </choose>
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countNovelsByRanking" resultType="long">
+        SELECT COUNT(*)
+        FROM novel
+        <where>
+            is_valid = true
+            <if test="categoryId != null and categoryId > 0">
+                AND category_id = #{categoryId,jdbcType=INTEGER}
+            </if>
+        </where>
+    </select>
+
+    <select id="selectAuthorsByRanking" resultType="com.yushan.backend.dto.AuthorResponseDTO">
+        SELECT
+        u.uuid as uuid,
+        u.username as username,
+        u.avatar_url as avatarUrl,
+        COUNT(n.id) as novelNum,
+        COALESCE(SUM(n.vote_cnt), 0) as totalVoteCnt,
+        COALESCE(SUM(n.view_cnt), 0) as totalViewCnt
+        FROM users u
+        LEFT JOIN novel n ON u.uuid = n.author_id AND n.is_valid = true
+        WHERE u.is_author = true
+        GROUP BY u.uuid, u.username, u.avatar_url
+        <choose>
+            <when test="sortType == 'novelNum'">
+                ORDER BY novelNum DESC, totalVoteCnt DESC, totalViewCnt DESC
+            </when>
+            <when test="sortType == 'vote'">
+                ORDER BY totalVoteCnt DESC, novelNum DESC, totalViewCnt DESC
+            </when>
+            <when test="sortType == 'view'">
+                ORDER BY totalViewCnt DESC, novelNum DESC, totalVoteCnt DESC
+            </when>
+            <otherwise>
+                ORDER BY novelNum DESC, totalVoteCnt DESC, totalViewCnt DESC
+            </otherwise>
+        </choose>
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -37,12 +37,33 @@
     from users
     where uuid = #{uuid,jdbcType=OTHER}
   </select>
+
   <select id="selectByEmail" parameterType="java.lang.String" resultMap="BaseResultMap">
     select
     <include refid="Base_Column_List" />
     from users
     where email = #{email,jdbcType=VARCHAR}
   </select>
+
+    <select id="selectUsersByRanking" resultMap="BaseResultMap">
+        SELECT
+        <include refid="Base_Column_List" />
+        FROM users
+        WHERE is_admin = false
+        ORDER BY exp DESC
+        LIMIT #{limit} OFFSET #{offset}
+    </select>
+
+    <select id="countAllUsers" resultType="long">
+        SELECT COUNT(*) FROM users
+    </select>
+
+    <select id="countAllAuthors" resultType="long">
+        SELECT COUNT(*)
+        FROM users
+        WHERE is_author = true
+    </select>
+
   <delete id="deleteByPrimaryKey" parameterType="java.util.UUID">
     delete from users
     where uuid = #{uuid,jdbcType=OTHER}

--- a/src/test/java/com/yushan/backend/JwtDemoTest.java
+++ b/src/test/java/com/yushan/backend/JwtDemoTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,6 +32,11 @@ public class JwtDemoTest {
         user.setUuid(UUID.randomUUID());
         user.setEmail("demo@example.com");
         user.setUsername("demo_user");
+        user.setEmailVerified(true);
+        user.setAvatarUrl("https://example.com/avatar.jpg");
+        user.setGender(1);
+        user.setLastLogin(new Date());
+        user.setLastActive(new Date());
         user.setIsAuthor(true);
 
         // Test token generation
@@ -66,6 +72,11 @@ public class JwtDemoTest {
         user.setUuid(UUID.randomUUID());
         user.setEmail("structure@example.com");
         user.setUsername("structure_user");
+        user.setEmailVerified(true);
+        user.setAvatarUrl("https://example.com/avatar.jpg");
+        user.setGender(1);
+        user.setLastLogin(new Date());
+        user.setLastActive(new Date());
         user.setIsAuthor(false);
 
         String token = jwtUtil.generateAccessToken(user);
@@ -87,12 +98,22 @@ public class JwtDemoTest {
         user1.setUuid(UUID.randomUUID());
         user1.setEmail("user1@example.com");
         user1.setUsername("user1");
+        user1.setEmailVerified(true);
+        user1.setAvatarUrl("https://example.com/avatar1.jpg");
+        user1.setGender(1);
+        user1.setLastLogin(new Date());
+        user1.setLastActive(new Date());
         user1.setIsAuthor(true);
 
         User user2 = new User();
         user2.setUuid(UUID.randomUUID());
         user2.setEmail("user2@example.com");
         user2.setUsername("user2");
+        user2.setEmailVerified(true);
+        user2.setAvatarUrl("https://example.com/avatar2.jpg");
+        user2.setGender(1);
+        user2.setLastLogin(new Date());
+        user2.setLastActive(new Date());
         user2.setIsAuthor(false);
 
         // Generate tokens for both users
@@ -124,6 +145,10 @@ public class JwtDemoTest {
         adminUser.setUsername("AdminUser");
         adminUser.setHashPassword("hashedpassword");
         adminUser.setEmailVerified(true);
+        adminUser.setAvatarUrl("https://example.com/admin-avatar.jpg");
+        adminUser.setGender(1);
+        adminUser.setLastLogin(new Date());
+        adminUser.setLastActive(new Date());
         adminUser.setStatus(1);
         adminUser.setIsAuthor(true);
         adminUser.setIsAdmin(true);  // Admin user
@@ -139,6 +164,10 @@ public class JwtDemoTest {
         normalUser.setUsername("NormalUser");
         normalUser.setHashPassword("hashedpassword");
         normalUser.setEmailVerified(true);
+        normalUser.setAvatarUrl("https://example.com/normal-avatar.jpg");
+        normalUser.setGender(1);
+        normalUser.setLastLogin(new Date());
+        normalUser.setLastActive(new Date());
         normalUser.setStatus(1);
         normalUser.setIsAuthor(false);
         normalUser.setIsAdmin(false);  // Normal user

--- a/src/test/java/com/yushan/backend/controller/AuthorControllerTest.java
+++ b/src/test/java/com/yushan/backend/controller/AuthorControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+import java.util.Date;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -60,6 +61,11 @@ class AuthorControllerTest {
             user.setEmail(annotation.email());
             user.setUsername("testuser");
             user.setHashPassword("password");
+            user.setEmailVerified(true);
+            user.setAvatarUrl("https://example.com/avatar.jpg");
+            user.setGender(1);
+            user.setLastLogin(new Date());
+            user.setLastActive(new Date());
             user.setIsAuthor(false);
             user.setIsAdmin(false);
 
@@ -107,6 +113,11 @@ class AuthorControllerTest {
         testUser.setUuid(UUID.randomUUID());
         testUser.setEmail(testEmail);
         testUser.setUsername("testuser");
+        testUser.setEmailVerified(true);
+        testUser.setAvatarUrl("https://example.com/avatar.jpg");
+        testUser.setGender(1);
+        testUser.setLastLogin(new Date());
+        testUser.setLastActive(new Date());
         testUser.setIsAuthor(false);
         testUser.setIsAdmin(false);
     }

--- a/src/test/java/com/yushan/backend/controller/RankingControllerTest.java
+++ b/src/test/java/com/yushan/backend/controller/RankingControllerTest.java
@@ -1,0 +1,100 @@
+package com.yushan.backend.controller;
+
+import com.yushan.backend.dto.PageResponseDTO;
+import com.yushan.backend.dto.NovelDetailResponseDTO;
+import com.yushan.backend.dto.UserProfileResponseDTO;
+import com.yushan.backend.dto.AuthorResponseDTO;
+import com.yushan.backend.service.RankingService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class RankingControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private RankingService rankingService;
+
+    @InjectMocks
+    private RankingController rankingController;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockMvc = MockMvcBuilders.standaloneSetup(rankingController).build();
+    }
+
+    @Test
+    void getNovelRanking_ShouldReturnSuccessResponse() throws Exception {
+        // Given
+        PageResponseDTO<NovelDetailResponseDTO> mockResponse = new PageResponseDTO<>();
+        when(rankingService.rankNovel(anyInt(), anyInt(), anyString(), any(), anyString()))
+                .thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/ranking/novel")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Novels retrieved successfully"));
+    }
+
+    @Test
+    void getUserRanking_ShouldReturnSuccessResponse() throws Exception {
+        // Given
+        PageResponseDTO<UserProfileResponseDTO> mockResponse = new PageResponseDTO<>();
+        when(rankingService.rankUser(anyInt(), anyInt(), anyString()))
+                .thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/ranking/user")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Novels retrieved successfully"));
+    }
+
+    @Test
+    void getAuthorRanking_ShouldReturnSuccessResponse() throws Exception {
+        // Given
+        PageResponseDTO<AuthorResponseDTO> mockResponse = new PageResponseDTO<>();
+        when(rankingService.rankAuthor(anyInt(), anyInt(), anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/ranking/author")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Novels retrieved successfully"));
+    }
+
+    @Test
+    void getNovelRanking_WithParameters_ShouldReturnSuccessResponse() throws Exception {
+        // Given
+        PageResponseDTO<NovelDetailResponseDTO> mockResponse = new PageResponseDTO<>();
+        when(rankingService.rankNovel(anyInt(), anyInt(), anyString(), any(), anyString()))
+                .thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/ranking/novel")
+                        .param("page", "1")
+                        .param("size", "20")
+                        .param("sortType", "vote")
+                        .param("category", "1")
+                        .param("timeRange", "weekly")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Novels retrieved successfully"));
+    }
+}

--- a/src/test/java/com/yushan/backend/security/JwtIntegrationTest.java
+++ b/src/test/java/com/yushan/backend/security/JwtIntegrationTest.java
@@ -22,6 +22,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Date;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -113,6 +114,11 @@ public class JwtIntegrationTest {
         testUser.setEmail("testuser@example.com");
         testUser.setUsername("testuser");
         testUser.setHashPassword(passwordEncoder.encode("password123"));
+        testUser.setEmailVerified(true);
+        testUser.setAvatarUrl("https://example.com/avatar.jpg");
+        testUser.setGender(1);
+        testUser.setLastLogin(new Date());
+        testUser.setLastActive(new Date());
         testUser.setIsAuthor(false);
         userMapper.insert(testUser);
 
@@ -122,6 +128,11 @@ public class JwtIntegrationTest {
         authorUser.setEmail("author@example.com");
         authorUser.setUsername("author");
         authorUser.setHashPassword(passwordEncoder.encode("password123"));
+        authorUser.setEmailVerified(true);
+        authorUser.setAvatarUrl("https://example.com/author-avatar.jpg");
+        authorUser.setGender(1);
+        authorUser.setLastLogin(new Date());
+        authorUser.setLastActive(new Date());
         authorUser.setIsAuthor(true);
         userMapper.insert(authorUser);
 
@@ -140,6 +151,10 @@ public class JwtIntegrationTest {
         user.setUsername(username);
         user.setHashPassword(passwordEncoder.encode("password123"));
         user.setEmailVerified(true);
+        user.setAvatarUrl("https://example.com/avatar.jpg");
+        user.setGender(1);
+        user.setLastLogin(new Date());
+        user.setLastActive(new Date());
         user.setStatus(1);
         user.setIsAuthor(isAuthor);
         user.setIsAdmin(isAdmin);

--- a/src/test/java/com/yushan/backend/security/SecurityExpressionRootTest.java
+++ b/src/test/java/com/yushan/backend/security/SecurityExpressionRootTest.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -38,6 +39,11 @@ public class SecurityExpressionRootTest {
         regularUser.setUuid(UUID.randomUUID());
         regularUser.setEmail("regular@example.com");
         regularUser.setUsername("regular");
+        regularUser.setEmailVerified(true);
+        regularUser.setAvatarUrl("https://example.com/avatar.jpg");
+        regularUser.setGender(1);
+        regularUser.setLastLogin(new Date());
+        regularUser.setLastActive(new Date());
         regularUser.setIsAuthor(false);
 
         // Create author user
@@ -45,6 +51,11 @@ public class SecurityExpressionRootTest {
         authorUser.setUuid(UUID.randomUUID());
         authorUser.setEmail("author@example.com");
         authorUser.setUsername("author");
+        authorUser.setEmailVerified(true);
+        authorUser.setAvatarUrl("https://example.com/avatar.jpg");
+        authorUser.setGender(1);
+        authorUser.setLastLogin(new Date());
+        authorUser.setLastActive(new Date());
         authorUser.setIsAuthor(true);
 
         // Create verified author user
@@ -52,6 +63,11 @@ public class SecurityExpressionRootTest {
         verifiedAuthorUser.setUuid(UUID.randomUUID());
         verifiedAuthorUser.setEmail("verified@example.com");
         verifiedAuthorUser.setUsername("verified");
+        verifiedAuthorUser.setEmailVerified(true);
+        verifiedAuthorUser.setAvatarUrl("https://example.com/avatar.jpg");
+        verifiedAuthorUser.setGender(1);
+        verifiedAuthorUser.setLastLogin(new Date());
+        verifiedAuthorUser.setLastActive(new Date());
         verifiedAuthorUser.setIsAuthor(true);
 
         // Create admin user
@@ -59,6 +75,11 @@ public class SecurityExpressionRootTest {
         adminUser.setUuid(UUID.randomUUID());
         adminUser.setEmail("admin@example.com");
         adminUser.setUsername("admin");
+        adminUser.setEmailVerified(true);
+        adminUser.setAvatarUrl("https://example.com/avatar.jpg");
+        adminUser.setGender(1);
+        adminUser.setLastLogin(new Date());
+        adminUser.setLastActive(new Date());
         adminUser.setIsAuthor(false);
         adminUser.setIsAdmin(true);
     }

--- a/src/test/java/com/yushan/backend/service/AdminServiceTest.java
+++ b/src/test/java/com/yushan/backend/service/AdminServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -40,6 +41,11 @@ class AdminServiceTest {
         testUser.setUuid(UUID.randomUUID());
         testUser.setEmail(testEmail);
         testUser.setUsername("testuser");
+        testUser.setEmailVerified(true);
+        testUser.setAvatarUrl("https://example.com/avatar.jpg");
+        testUser.setGender(1);
+        testUser.setLastLogin(new Date());
+        testUser.setLastActive(new Date());
         testUser.setIsAuthor(false);
         testUser.setIsAdmin(false);
 

--- a/src/test/java/com/yushan/backend/service/AuthorServiceTest.java
+++ b/src/test/java/com/yushan/backend/service/AuthorServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -48,6 +49,11 @@ class AuthorServiceTest {
         testUser.setUuid(UUID.randomUUID());
         testUser.setEmail(testEmail);
         testUser.setUsername("testuser");
+        testUser.setEmailVerified(true);
+        testUser.setAvatarUrl("https://example.com/avatar.jpg");
+        testUser.setGender(1);
+        testUser.setLastLogin(new Date());
+        testUser.setLastActive(new Date());
         testUser.setIsAuthor(false);
         testUser.setIsAdmin(false);
 

--- a/src/test/java/com/yushan/backend/service/RankingServiceTest.java
+++ b/src/test/java/com/yushan/backend/service/RankingServiceTest.java
@@ -1,0 +1,135 @@
+package com.yushan.backend.service;
+
+import com.yushan.backend.dto.AuthorResponseDTO;
+import com.yushan.backend.dto.NovelDetailResponseDTO;
+import com.yushan.backend.dto.PageResponseDTO;
+import com.yushan.backend.dto.UserProfileResponseDTO;
+import com.yushan.backend.entity.Novel;
+import com.yushan.backend.dao.NovelMapper;
+import com.yushan.backend.dao.UserMapper;
+import com.yushan.backend.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RankingServiceTest {
+
+    @Mock
+    private NovelMapper novelMapper;
+
+    @Mock
+    private UserMapper userMapper;
+
+    @InjectMocks
+    private RankingService rankingService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void rankNovel_ShouldReturnPagedResponse() {
+        // Given
+        List<Novel> mockNovels = Arrays.asList(createMockNovel(1), createMockNovel(2));
+        when(novelMapper.selectNovelsByRanking(any(), anyString(), anyInt(), anyInt()))
+                .thenReturn(mockNovels);
+        when(novelMapper.countNovelsByRanking(any())).thenReturn(2L);
+
+        // When
+        PageResponseDTO<NovelDetailResponseDTO> result = rankingService.rankNovel(0, 10, "view", 1, "overall");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.getContent().size());
+        assertEquals(2L, result.getTotalElements());
+        assertEquals(0, result.getCurrentPage());
+        assertEquals(10, result.getSize());
+        verify(novelMapper).selectNovelsByRanking(1, "view", 0, 10);
+        verify(novelMapper).countNovelsByRanking(1);
+    }
+
+    @Test
+    void rankNovel_WhenOffsetExceedsMaxRecords_ShouldReturnEmptyResponse() {
+        // When
+        PageResponseDTO<NovelDetailResponseDTO> result = rankingService.rankNovel(10, 20, "view", null, "overall");
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.getContent().isEmpty());
+        assertEquals(0L, result.getTotalElements());
+        assertEquals(10, result.getCurrentPage());
+        assertEquals(20, result.getSize());
+    }
+
+    @Test
+    void rankUser_ShouldReturnPagedResponse() {
+        // Given
+        List<User> mockUsers = Arrays.asList(createMockUser(UUID.randomUUID()), createMockUser(UUID.randomUUID()));
+        when(userMapper.selectUsersByRanking(anyInt(), anyInt())).thenReturn(mockUsers);
+        when(userMapper.countAllUsers()).thenReturn(2L);
+
+        // When
+        PageResponseDTO<UserProfileResponseDTO> result = rankingService.rankUser(0, 10, "overall");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.getContent().size());
+        assertEquals(2L, result.getTotalElements());
+        assertEquals(0, result.getCurrentPage());
+        assertEquals(10, result.getSize());
+        verify(userMapper).selectUsersByRanking(0, 10);
+        verify(userMapper).countAllUsers();
+    }
+
+    @Test
+    void rankAuthor_ShouldReturnPagedResponse() {
+        // Given
+        List<AuthorResponseDTO> mockAuthors = Arrays.asList(new AuthorResponseDTO(), new AuthorResponseDTO());
+        when(novelMapper.selectAuthorsByRanking(anyString(), anyInt(), anyInt())).thenReturn(mockAuthors);
+        when(userMapper.countAllAuthors()).thenReturn(2L);
+
+        // When
+        PageResponseDTO<AuthorResponseDTO> result = rankingService.rankAuthor(0, 10, "vote", "overall");
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.getContent().size());
+        assertEquals(2L, result.getTotalElements());
+        assertEquals(0, result.getCurrentPage());
+        assertEquals(10, result.getSize());
+        verify(novelMapper).selectAuthorsByRanking("vote", 0, 10);
+        verify(userMapper).countAllAuthors();
+    }
+
+    private Novel createMockNovel(Integer id) {
+        Novel novel = new Novel();
+        novel.setId(id);
+        novel.setTitle("Test Novel " + id);
+        novel.setViewCnt(100L);
+        novel.setVoteCnt(50);
+        novel.setCoverImgUrl("cover.jpg");
+        novel.setCategoryId(1);
+        return novel;
+    }
+
+    private User createMockUser(UUID id) {
+        User user = new User();
+        user.setUuid(id);
+        user.setUuid(UUID.randomUUID());
+        user.setUsername("testuser" + id);
+        user.setExp(100f);
+        user.setLevel(1);
+        user.setAvatarUrl("avatar.jpg");
+        return user;
+    }
+}

--- a/src/test/java/com/yushan/backend/service/RankingServiceTest.java
+++ b/src/test/java/com/yushan/backend/service/RankingServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -127,9 +128,13 @@ class RankingServiceTest {
         user.setUuid(id);
         user.setUuid(UUID.randomUUID());
         user.setUsername("testuser" + id);
+        user.setEmailVerified(true);
+        user.setAvatarUrl("avatar.jpg");
+        user.setGender(1);
+        user.setLastLogin(new Date());
+        user.setLastActive(new Date());
         user.setExp(100f);
         user.setLevel(1);
-        user.setAvatarUrl("avatar.jpg");
         return user;
     }
 }

--- a/src/test/java/com/yushan/backend/service/UserServiceTest.java
+++ b/src/test/java/com/yushan/backend/service/UserServiceTest.java
@@ -59,9 +59,12 @@ public class UserServiceTest {
         existing.setUuid(id);
         existing.setEmail("old@example.com");
         existing.setUsername("oldname");
+        existing.setEmailVerified(true);
         existing.setAvatarUrl("old.png");
         existing.setProfileDetail("old profile");
         existing.setGender(1);
+        existing.setLastLogin(new Date());
+        existing.setLastActive(new Date());
         existing.setReadTime(10.5f);
         existing.setReadBookNum(5);
 
@@ -71,9 +74,12 @@ public class UserServiceTest {
         after.setUuid(id);
         after.setEmail("old@example.com");
         after.setUsername("newname");
+        after.setEmailVerified(true);
         after.setAvatarUrl("new.png");
         after.setProfileDetail("new profile");
         after.setGender(2);
+        after.setLastLogin(new Date());
+        after.setLastActive(new Date());
         after.setReadTime(10.5f);
         after.setReadBookNum(5);
         after.setUpdateTime(new Date());
@@ -118,6 +124,11 @@ public class UserServiceTest {
         User existing = new User();
         existing.setUuid(id);
         existing.setEmail("old@example.com");
+        existing.setEmailVerified(true);
+        existing.setAvatarUrl("https://example.com/avatar.jpg");
+        existing.setGender(1);
+        existing.setLastLogin(new Date());
+        existing.setLastActive(new Date());
         when(userMapper.selectByPrimaryKey(id)).thenReturn(existing);
 
         UserProfileUpdateRequestDTO req = new UserProfileUpdateRequestDTO();
@@ -133,6 +144,11 @@ public class UserServiceTest {
         User existing = new User();
         existing.setUuid(id);
         existing.setEmail("old@example.com");
+        existing.setEmailVerified(true);
+        existing.setAvatarUrl("https://example.com/avatar.jpg");
+        existing.setGender(1);
+        existing.setLastLogin(new Date());
+        existing.setLastActive(new Date());
         when(userMapper.selectByPrimaryKey(id)).thenReturn(existing);
 
         when(mailService.verifyEmail("new@example.com", "000000")).thenReturn(false);
@@ -151,11 +167,21 @@ public class UserServiceTest {
         User existing = new User();
         existing.setUuid(id);
         existing.setEmail("old@example.com");
+        existing.setEmailVerified(true);
+        existing.setAvatarUrl("https://example.com/avatar.jpg");
+        existing.setGender(1);
+        existing.setLastLogin(new Date());
+        existing.setLastActive(new Date());
 
         User after = new User();
         after.setUuid(id);
         after.setEmail("new@example.com");
         after.setUsername("same");
+        after.setEmailVerified(true);
+        after.setAvatarUrl("https://example.com/avatar.jpg");
+        after.setGender(1);
+        after.setLastLogin(new Date());
+        after.setLastActive(new Date());
 
         when(userMapper.selectByPrimaryKey(id)).thenReturn(existing, after);
         when(userMapper.selectByEmail("new@example.com")).thenReturn(null);
@@ -196,6 +222,11 @@ public class UserServiceTest {
         adminUser.setUuid(id);
         adminUser.setEmail("admin@example.com");
         adminUser.setUsername("AdminUser");
+        adminUser.setEmailVerified(true);
+        adminUser.setAvatarUrl("https://example.com/admin-avatar.jpg");
+        adminUser.setGender(1);
+        adminUser.setLastLogin(new Date());
+        adminUser.setLastActive(new Date());
         adminUser.setIsAuthor(true);
         adminUser.setIsAdmin(true);  // Admin user
         adminUser.setLevel(5);
@@ -226,6 +257,11 @@ public class UserServiceTest {
         normalUser.setUuid(id);
         normalUser.setEmail("normal@example.com");
         normalUser.setUsername("NormalUser");
+        normalUser.setEmailVerified(true);
+        normalUser.setAvatarUrl("https://example.com/normal-avatar.jpg");
+        normalUser.setGender(1);
+        normalUser.setLastLogin(new Date());
+        normalUser.setLastActive(new Date());
         normalUser.setIsAuthor(false);
         normalUser.setIsAdmin(false);  // Normal user
         normalUser.setLevel(1);

--- a/src/test/java/com/yushan/backend/util/JwtUtilTest.java
+++ b/src/test/java/com/yushan/backend/util/JwtUtilTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.Date;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,6 +32,11 @@ public class JwtUtilTest {
         testUser.setUuid(UUID.randomUUID());
         testUser.setEmail("test@example.com");
         testUser.setUsername("testuser");
+        testUser.setEmailVerified(true);
+        testUser.setAvatarUrl("https://example.com/avatar.jpg");
+        testUser.setGender(1);
+        testUser.setLastLogin(new Date());
+        testUser.setLastActive(new Date());
         testUser.setIsAuthor(true);
     }
 
@@ -90,6 +96,11 @@ public class JwtUtilTest {
         User differentUser = new User();
         differentUser.setUuid(UUID.randomUUID());
         differentUser.setEmail("different@example.com");
+        differentUser.setEmailVerified(true);
+        differentUser.setAvatarUrl("https://example.com/avatar.jpg");
+        differentUser.setGender(1);
+        differentUser.setLastLogin(new Date());
+        differentUser.setLastActive(new Date());
         
         assertFalse(jwtUtil.validateToken(token, differentUser), "Token with wrong user should fail validation");
     }

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -16,9 +16,9 @@ CREATE TABLE IF NOT EXISTS users (
     is_author BOOLEAN DEFAULT FALSE,
     is_admin BOOLEAN DEFAULT FALSE,
     level INTEGER DEFAULT 1,
-    exp FLOAT DEFAULT 0.0,
-    yuan FLOAT DEFAULT 0.0,
-    read_time FLOAT DEFAULT 0.0,
+    exp DOUBLE DEFAULT 0.0,
+    yuan DOUBLE DEFAULT 0.0,
+    read_time DOUBLE DEFAULT 0.0,
     read_book_num INTEGER DEFAULT 0,
     create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS category (
     id SERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     description VARCHAR(255),
-    slug VARCHAR(100),
+    slug VARCHAR(100) UNIQUE NOT NULL,
     is_active BOOLEAN DEFAULT TRUE,
     create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -57,7 +57,9 @@ CREATE TABLE IF NOT EXISTS novel (
     yuan_cnt REAL DEFAULT 0.0,
     create_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    publish_time TIMESTAMP
+    publish_time TIMESTAMP,
+    CONSTRAINT fk_novel_author FOREIGN KEY (author_id) REFERENCES users(uuid),
+    CONSTRAINT fk_novel_category FOREIGN KEY (category_id) REFERENCES category(id)
 );
 
 CREATE TABLE IF NOT EXISTS library (


### PR DESCRIPTION
🎯 Objective

Implement backend APIs to support leaderboards for Novels, Users, and Authors APIs will provide ranked lists based on different metrics (e.g., views, likes, favorites, ratings, activity) and time ranges (daily, weekly, monthly, all-time). The goal is to deliver a unified, performant, and extensible interface for the frontend to display rankings.

📦 Scope

Leaderboard Types

Novels Leaderboard

Ranked by views, votes, sort time

Users Leaderboard

Ranked by exp

Authors Leaderboard

Ranked by aggregated stats across all works (novel num, total views, total votes, sort time)

API Features

Fetch leaderboard by type (novels | users | authors)

Support metric selection (views | votes | sort time | exp)

Support time range filtering (weekly | monthly | all)

Pagination support

Return rank, entity info, and metric value

Data Source

Based on existing entities (Novel, User, Writer) and related statistics (reads, likes, favorites, comments)

Introduce aggregation queries or caching layer for performance optimization

✅ Acceptance Criteria

[ ] RESTful API endpoint: /api/leaderboards/{type}

[ ] Query parameters: metric, timeRange, page, size

[ ] Response includes: rank, entity ID, name/title, metric value

[ ] Response time ≤ 500ms (with cache hit)

[ ] Swagger/OpenAPI documentation with request/response examples

[ ] Unit tests with ≥ 80% coverage, including edge cases (empty data, invalid params, pagination boundaries)